### PR TITLE
fix: increase life time of access and refresh tokens

### DIFF
--- a/SimpleNote/settings/base.py
+++ b/SimpleNote/settings/base.py
@@ -107,8 +107,8 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=30),
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=7),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=30),
     'ROTATE_REFRESH_TOKENS': False,
     'BLACKLIST_AFTER_ROTATION': True,
 }


### PR DESCRIPTION
Life time of access and refresh tokens are way too short. It is inconvinient for developers to login every day (in case of implementing refresh tokens).