### PR TITLE
feat: add change password endpoint

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -29,3 +29,16 @@ class UserInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ['id', 'username', 'email', 'first_name', 'last_name']
+
+
+class ChangePasswordSerializer(serializers.Serializer):
+    old_password = serializers.CharField(required=True)
+    new_password = serializers.CharField(
+        required=True, validators=[validate_password]
+    )
+
+    def validate_old_password(self, value):
+        user = self.context['request'].user
+        if not user.check_password(value):
+            raise serializers.ValidationError('Old password is not correct.')
+        return value

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -1,5 +1,9 @@
 from django.urls import path
-from authentication.views import RegisterView, UserInfoView
+from authentication.views import (
+    RegisterView,
+    UserInfoView,
+    ChangePasswordView
+)
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 urlpatterns = [
@@ -7,4 +11,5 @@ urlpatterns = [
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('register/', RegisterView.as_view(), name='auth_register'),
     path('userinfo/', UserInfoView.as_view(), name='user_info'),
+    path('change-password/', ChangePasswordView.as_view(), name='change_password'),
 ]

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -4,7 +4,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
-from .serializers import RegisterSerializer, UserInfoSerializer
+from .serializers import RegisterSerializer, UserInfoSerializer, ChangePasswordSerializer
 
 
 class RegisterView(generics.CreateAPIView):
@@ -20,3 +20,20 @@ class UserInfoView(APIView):
     def get(self, request):
         serializer = UserInfoSerializer(request.user)
         return Response(serializer.data)
+
+class ChangePasswordView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        serializer = ChangePasswordSerializer(
+            data=request.data, context={'request': request}
+        )
+        serializer.is_valid(raise_exception=True)
+
+        request.user.set_password(serializer.validated_data['new_password'])
+        request.user.save()
+
+        return Response(
+            {'detail': 'Password changed successfully.'},
+            status=200,
+        )


### PR DESCRIPTION
In the design of the project, there was a page in the settings related to changing password. But the backend endpoint of it wasn't implemented. I added it.